### PR TITLE
docs: Add curl examples for shared secret authentication

### DIFF
--- a/docs/auth_plugins.md
+++ b/docs/auth_plugins.md
@@ -345,6 +345,13 @@ auth:
   header: Authorization
 ```
 
+```bash
+curl -X POST "https://your-hooks-server.com/webhooks/example" \
+  -H "Authorization: your-shared-secret" \
+  -H "Content-Type: application/json" \
+  -d '{"event":"test","data":"example"}'
+```
+
 **Custom header shared secret:**
 
 ```yaml
@@ -353,6 +360,14 @@ auth:
   secret_env_key: API_KEY_SECRET
   header: X-API-Key
 ```
+
+```bash
+curl -X POST "https://your-hooks-server.com/webhooks/example" \
+  -H "X-API-Key: your-shared-secret" \
+  -H "Content-Type: application/json" \
+  -d '{"event":"test","data":"example"}'
+```
+
 
 ## Custom Auth Plugins
 

--- a/docs/auth_plugins.md
+++ b/docs/auth_plugins.md
@@ -368,6 +368,7 @@ curl -X POST "https://your-hooks-server.com/webhooks/example" \
   -d '{"event":"test","data":"example"}'
 ```
 
+> **Note:** The shared secret is sent as plain text directly in the header value. No `Bearer` prefix or encoding is required. Always use HTTPS to protect the secret in transit.
 
 ## Custom Auth Plugins
 


### PR DESCRIPTION
## Summary

Adds curl request examples to the Shared Secret Authentication section to clarify usage.

## Changes

- Added curl examples showing how to send requests with `Authorization` and `X-API-Key` headers
- Added note clarifying that no `Bearer` prefix or encoding is required (plain text comparison)
- Added reminder to always use HTTPS since the secret is transmitted in plain text